### PR TITLE
Override flag

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,7 @@
         },
         {
             
-            "name": "Program Load",
+            "name": "Override Program Load",
             "type": "go",
             "request": "launch",
             "mode": "auto",
@@ -45,9 +45,9 @@
             "args": [
                 "-h", "10.0.0.111",
                 "-t","eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6Ijk0NDliMDM0LTcyNWEtNDM0Ny04YTMzLTc5Zjg2MDNlYjUyYiIsImx2IjoiRGVmYXVsdCBMZXZlbCIsInZlciI6IjEuMCIsImV4cGkiOiIwIn0.oMs434gmWR-x4sTGKonmndOA5F62FdzrwYZQYSGNd2A",
-                "-f", "C:\\Users\\ewilliams\\OneDrive - cenero.com\\Documents\\Projects\\Wharton\\Gacialis\\Programs\\Wharton_Glacialis_QsysCR_v3.0.0.lpz",
+                "-f", "C:\\Users\\ewilliams\\OneDrive - cenero.com\\Documents\\Projects\\WWF\\CEN22-9238\\Control Code\\9238_WWF_MPR_CP4N_v3.4.lpz",
                 "-n", "Wharton Template",
-                "-o", "true"
+                "-o"
             ],
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,22 @@
         },
         {
             
+            "name": "Program Load",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "./cmd/vcli/",
+            "console": "externalTerminal",
+            "args": [
+                "-h", "10.0.0.111",
+                "-t","eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6Ijk0NDliMDM0LTcyNWEtNDM0Ny04YTMzLTc5Zjg2MDNlYjUyYiIsImx2IjoiRGVmYXVsdCBMZXZlbCIsInZlciI6IjEuMCIsImV4cGkiOiIwIn0.oMs434gmWR-x4sTGKonmndOA5F62FdzrwYZQYSGNd2A",
+                "-f", "C:\\Users\\ewilliams\\OneDrive - cenero.com\\Documents\\Projects\\Wharton\\Gacialis\\Programs\\Wharton_Glacialis_QsysCR_v3.0.0.lpz",
+                "-n", "Wharton Template",
+                "-o", "true"
+            ],
+        },
+        {
+            
             "name": "Create And Run Room",
             "type": "go",
             "request": "launch",

--- a/pkg/tui/flags.go
+++ b/pkg/tui/flags.go
@@ -18,17 +18,20 @@ var (
 	RoomID string
 	// Actions include GET PUT DEL and can be used with a combination of the Room ID and program file flags
 	Action string
+	// When the -o flag is provided the application will override the provided room.
+	OverrideFile bool
 )
 
 func InitFlags() {
 	const (
-		defaultHost    = "127.0.0.1"
-		defaultToken   = ""
-		hostFlagUsage  = "The IP or hostname of the virtual control service"
-		tokenFlagUsage = "The API token generated from the VC4 webpage, this is required to control an external appliance"
-		progFlagUsage  = "An optional flag to load a program file"
-		nameFagUsage   = "An optional glag used to name the loaded program flag"
-		roomFlagUsage  = "An optional room ID used to spin up a new room"
+		defaultHost       = "127.0.0.1"
+		defaultToken      = ""
+		hostFlagUsage     = "The IP or hostname of the virtual control service"
+		tokenFlagUsage    = "The API token generated from the VC4 webpage, this is required to control an external appliance"
+		progFlagUsage     = "An optional flag to load a program file"
+		nameFagUsage      = "An optional glag used to name the loaded program flag"
+		roomFlagUsage     = "An optional room ID used to spin up a new room"
+		overrideFlagUsage = "An option flag to let the application know to override the provided program file"
 	)
 
 	flag.StringVar(&Hostname, "host", defaultHost, hostFlagUsage)
@@ -44,4 +47,7 @@ func InitFlags() {
 
 	flag.StringVar(&ProgramName, "name", "", nameFagUsage)
 	flag.StringVar(&ProgramName, "n", "", nameFagUsage+" (shorthand)")
+
+	flag.BoolVar(&OverrideFile, "override", false, overrideFlagUsage)
+	flag.BoolVar(&OverrideFile, "o", false, overrideFlagUsage+" (shorthand)")
 }


### PR DESCRIPTION
added a new -o or -override flag to force a program reload.  When launching the vcli with -file and -name  and -o the name will be matched and that specific program entry will be loaded.  All effected rooms will be restarted so BE CAREFUL